### PR TITLE
Refactor viewpoint and reaction endpoint response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,7 +8,7 @@ servers:
 paths:
   # Issue
   /issue/{id}/viewpoints:
-    $ref: "./paths/viewpoint.yaml#/ViewPoints"
+    $ref: "./paths/viewpoint.yaml#/IssueViewPoints"
   # ViewPoint
   /api/viewpoints:
     $ref: "./paths/viewpoint.yaml#/ViewPoints"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,18 +11,8 @@ paths:
     $ref: "./paths/viewpoint.yaml#/ViewPoints"
   /api/viewpoint/{id}:
     $ref: "./paths/viewpoint.yaml#/ViewPoint"
-  /api/viewpoint/{id}/likes:
-    $ref: "./paths/viewpoint.yaml#/ViewPointLikes"
-  /api/viewpoint/{id}/like/me:
-    $ref: "./paths/viewpoint.yaml#/ViewPointLikeMe"
-  /api/viewpoint/{id}/reasonables:
-    $ref: "./paths/viewpoint.yaml#/ViewPointReasonables"
-  /api/viewpoint/{id}/reasonable/me:
-    $ref: "./paths/viewpoint.yaml#/ViewPointReasonableMe"
-  /api/viewpoint/{id}/dislikes:
-    $ref: "./paths/viewpoint.yaml#/ViewPointDislikes"
-  /api/viewpoint/{id}/dislike/me:
-    $ref: "./paths/viewpoint.yaml#/ViewPointDislikeMe"
+  /api/viewpoint/{id}/reaction/me:
+    $ref: "./paths/viewpoint.yaml#/ViewPointReaction"
   /api/viewpoint/{id}/facts:
     $ref: "./paths/viewpoint.yaml#/ViewPointFacts"
   /api/viewpoint/{id}/fact/{factId}:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,6 +7,10 @@ servers:
   - url: https://your-api-server.com
 paths:
   # Issue
+  #  /issues:
+  #    $ref: "./paths/issue.yaml#/Issues"
+  #  /issue/{id}:
+  #    $ref: "./paths/issue.yaml#/Issue"
   /issue/{id}/viewpoints:
     $ref: "./paths/viewpoint.yaml#/IssueViewPoints"
   # ViewPoint
@@ -27,3 +31,22 @@ paths:
     $ref: "./paths/fact.yaml#/Fact"
   /api/fact/{id}/references:
     $ref: "./paths/fact.yaml#/FactReferences"
+
+components:
+  schemas:
+    ViewPoint:
+      $ref: "./schemas/viewpoint.yaml#/ViewPoint"
+    UpdateViewPoint:
+      $ref: "./schemas/viewpoint.yaml#/UpdateViewPoint"
+    ViewPointReaction:
+      $ref: "./schemas/viewpoint.yaml#/ViewPointReaction"
+    Fact:
+      $ref: "./schemas/fact.yaml#/Fact"
+    UpdateFact:
+      $ref: "./schemas/fact.yaml#/UpdateFact"
+    Reference:
+      $ref: "./schemas/reference.yaml#/Reference"
+    UpdateReference:
+      $ref: "./schemas/reference.yaml#/UpdateReference"
+    Pagination:
+      $ref: "./schemas/page.yaml#/Page"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,6 +6,9 @@ info:
 servers:
   - url: https://your-api-server.com
 paths:
+  # Issue
+  /issue/{id}/viewpoints:
+    $ref: "./paths/viewpoint.yaml#/ViewPoints"
   # ViewPoint
   /api/viewpoints:
     $ref: "./paths/viewpoint.yaml#/ViewPoints"

--- a/parameters/requestId.yaml
+++ b/parameters/requestId.yaml
@@ -1,8 +1,8 @@
-RequestId:
+RequestUid:
   name: id
   in: path
   required: true
-  description: The uuid of request
+  description: The uuid of specific resource
   schema:
     type: string
     format: uuid

--- a/paths/fact.yaml
+++ b/paths/fact.yaml
@@ -104,7 +104,7 @@ FactReferences:
   get:
     summary: List references of specific fact
     description: This endpoint returns references of specific fact by fact id
-    operationId: getFactReferences
+    operationId: getReferencesOfFact
     tags:
       - Fact
     parameters:
@@ -150,7 +150,7 @@ FactReferences:
   delete:
     summary: Delete selected reference
     description: This endpoint is used to delete specific reference by reference id
-    operationId: deletedReference
+    operationId: deleteReference
     tags:
       - Fact
     parameters:

--- a/paths/fact.yaml
+++ b/paths/fact.yaml
@@ -55,7 +55,7 @@ Fact:
     tags:
       - Fact
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     responses:
       '200':
         description: Successful response
@@ -73,7 +73,7 @@ Fact:
     tags:
       - Fact
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     requestBody:
       required: true
       content:
@@ -95,7 +95,7 @@ Fact:
     tags:
       - Fact
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     responses:
       204:
         $ref: "../definitions/processSuccess.yaml"
@@ -108,7 +108,7 @@ FactReferences:
     tags:
       - Fact
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     responses:
       '200':
         description: Successful response
@@ -125,7 +125,7 @@ FactReferences:
     tags:
       - Fact
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     requestBody:
       required: true
       content:
@@ -154,7 +154,7 @@ FactReferences:
     tags:
       - Fact
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     responses:
       '204':
         $ref: "../definitions/processSuccess.yaml"

--- a/paths/fact.yaml
+++ b/paths/fact.yaml
@@ -38,10 +38,7 @@ Facts:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              title:
-                type: string
+            $ref: "../schemas/fact.yaml#/UpdateFact"
     responses:
       '200':
         description: Successful response
@@ -82,10 +79,7 @@ Fact:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              title:
-                type: string
+            $ref: "../schemas/fact.yaml#/UpdateFact"
     responses:
       '200':
         description: Successful response

--- a/paths/viewpoint.yaml
+++ b/paths/viewpoint.yaml
@@ -1,8 +1,57 @@
+IssueViewPoints:
+  get:
+    summary: List viewpoints
+    description: This endpoint returns all viewpoints of an issue
+    operationId: getViewpointsByIssue
+    tags:
+      - Issue
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/sort.yaml#/Sort"
+      - $ref: "../parameters/page.yaml#/Page"
+      - $ref: "../parameters/size.yaml#/Size"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                embedded:
+                  type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        $ref: "../schemas/viewpoint.yaml#/ViewPoint"
+                page:
+                  $ref: "../schemas/page.yaml#/Page"
+  post:
+    summary: Create a new viewpoint
+    description: This endpoint is used to create a new viewpoint for an issue
+    operationId: createViewPoint
+    tags:
+      - Issue
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/viewpoint.yaml#/UpdateViewPoint"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/viewpoint.yaml#/ViewPoint"
+
 ViewPoints:
   get:
     summary: List viewpoints
     description: This endpoint returns all viewpoints
-    operationId: getFactsList
+    operationId: getViewPoints
     tags:
       - ViewPoint
     parameters:
@@ -31,7 +80,7 @@ ViewPoint:
   get:
     summary: Get specific viewpoint information
     description: This endpoint returns specific fact information by fact id
-    operationId: getFact
+    operationId: getViewPoint
     tags:
       - ViewPoint
     parameters:
@@ -81,40 +130,11 @@ ViewPoint:
       '204':
         description: No content
 
-ViewPointLikes:
-  get:
-    summary: List likes of a viewpoint
-    description: This endpoint returns all likes of a viewpoint
-    operationId: getLikesListOfViewPoint
-    tags:
-      - ViewPoint
-    parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
-      - $ref: "../parameters/page.yaml#/Page"
-      - $ref: "../parameters/size.yaml#/Size"
-    responses:
-      '200':
-        description: Successful response
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                embedded:
-                  type: object
-                  properties:
-                    data:
-                      type: array
-                      items:
-                        $ref: "../schemas/user.yaml#/SimpleUser"
-                page:
-                  $ref: "../schemas/page.yaml#/Page"
-
 ViewPointReaction:
   post:
-    summary: Like a viewpoint
-    description: This endpoint is used to like a viewpoint
-    operationId: likeViewPoint
+    summary: React to a viewpoint
+    description: This endpoint is used to react to a viewpoint
+    operationId: reactToViewPoint
     tags:
       - ViewPoint
     parameters:
@@ -137,7 +157,7 @@ ViewPointFacts:
   get:
     summary: List facts of a viewpoint
     description: This endpoint returns all facts of a viewpoint
-    operationId: getFactsListOfViewPoint
+    operationId: getFactsOfViewPoint
     tags:
       - ViewPoint
     parameters:
@@ -178,6 +198,7 @@ ViewPointFacts:
             properties:
               factId:
                 type: string
+                format: uuid
     responses:
       '204':
         description: No content

--- a/paths/viewpoint.yaml
+++ b/paths/viewpoint.yaml
@@ -110,7 +110,7 @@ ViewPointLikes:
                 page:
                   $ref: "../schemas/page.yaml#/Page"
 
-ViewPointLikeMe:
+ViewPointReaction:
   post:
     summary: Like a viewpoint
     description: This endpoint is used to like a viewpoint
@@ -119,98 +119,12 @@ ViewPointLikeMe:
       - ViewPoint
     parameters:
       - $ref: "../parameters/requestId.yaml#/RequestId"
-    responses:
-      '200':
-        description: Successful response
-        content:
-          application/json:
-            schema:
-              $ref: "../schemas/viewpoint.yaml#/ViewPointReaction"
-
-ViewPointReasonables:
-  get:
-    summary: List reasonables of a viewpoint
-    description: This endpoint returns all reasonables of a viewpoint
-    operationId: getReasonablesListOFViewPoint
-    tags:
-      - ViewPoint
-    parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
-      - $ref: "../parameters/page.yaml#/Page"
-      - $ref: "../parameters/size.yaml#/Size"
-    responses:
-      '200':
-        description: Successful response
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                embedded:
-                  type: object
-                  properties:
-                    data:
-                      type: array
-                      items:
-                        $ref: "../schemas/user.yaml#/SimpleUser"
-                page:
-                  $ref: "../schemas/page.yaml#/Page"
-
-ViewPointReasonableMe:
-  post:
-    summary: Reasonable a viewpoint
-    description: This endpoint is used to reasonable a viewpoint
-    operationId: reasonableViewPoint
-    tags:
-      - ViewPoint
-    parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
-    responses:
-      '200':
-        description: Successful response
-        content:
-          application/json:
-            schema:
-              $ref: "../schemas/viewpoint.yaml#/ViewPointReaction"
-
-ViewPointDislikes:
-  get:
-    summary: List dislikes of a viewpoint
-    description: This endpoint returns all dislikes of a viewpoint
-    operationId: getDislikesListOfViewPoint
-    tags:
-      - ViewPoint
-    parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
-      - $ref: "../parameters/page.yaml#/Page"
-      - $ref: "../parameters/size.yaml#/Size"
-    responses:
-      '200':
-        description: Successful response
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                embedded:
-                  type: object
-                  properties:
-                    data:
-                      type: array
-                      items:
-                        $ref: "../schemas/user.yaml#/SimpleUser"
-                page:
-                  $ref: "../schemas/page.yaml#/Page"
-
-ViewPointDislikeMe:
-  post:
-    summary: Dislike a viewpoint
-    description: This endpoint is used to dislike a viewpoint
-    operationId: dislikeViewPoint
-    tags:
-      - ViewPoint
-    parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/viewpoint.yaml#/ViewPointReaction"
     responses:
       '200':
         description: Successful response

--- a/paths/viewpoint.yaml
+++ b/paths/viewpoint.yaml
@@ -6,7 +6,7 @@ IssueViewPoints:
     tags:
       - Issue
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
       - $ref: "../parameters/sort.yaml#/Sort"
       - $ref: "../parameters/page.yaml#/Page"
       - $ref: "../parameters/size.yaml#/Size"
@@ -79,12 +79,12 @@ ViewPoints:
 ViewPoint:
   get:
     summary: Get specific viewpoint information
-    description: This endpoint returns specific fact information by fact id
+    description: This endpoint returns specific viewpoint information by viewpoint id
     operationId: getViewPoint
     tags:
       - ViewPoint
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     responses:
       '200':
         description: Successful response
@@ -99,18 +99,13 @@ ViewPoint:
     tags:
       - ViewPoint
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     requestBody:
       required: true
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              title:
-                type: string
-              content:
-                type: string
+            $ref: "../schemas/viewpoint.yaml#/UpdateViewPoint"
     responses:
       '200':
         description: Successful response
@@ -125,7 +120,7 @@ ViewPoint:
     tags:
       - ViewPoint
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     responses:
       '204':
         description: No content
@@ -138,7 +133,7 @@ ViewPointReaction:
     tags:
       - ViewPoint
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     requestBody:
       required: true
       content:
@@ -161,7 +156,7 @@ ViewPointFacts:
     tags:
       - ViewPoint
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
       - $ref: "../parameters/page.yaml#/Page"
       - $ref: "../parameters/size.yaml#/Size"
     responses:
@@ -188,7 +183,7 @@ ViewPointFacts:
     tags:
       - ViewPoint
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
     requestBody:
       required: true
       content:
@@ -211,7 +206,7 @@ ViewPointFact:
     tags:
       - ViewPoint
     parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestId"
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
       - name: factId
         in: path
         required: true

--- a/paths/viewpoint.yaml
+++ b/paths/viewpoint.yaml
@@ -125,7 +125,7 @@ ViewPointLikeMe:
         content:
           application/json:
             schema:
-              $ref: "../schemas/viewpoint.yaml#/ViewPoint"
+              $ref: "../schemas/viewpoint.yaml#/ViewPointReaction"
 
 ViewPointReasonables:
   get:
@@ -171,7 +171,7 @@ ViewPointReasonableMe:
         content:
           application/json:
             schema:
-              $ref: "../schemas/viewpoint.yaml#/ViewPoint"
+              $ref: "../schemas/viewpoint.yaml#/ViewPointReaction"
 
 ViewPointDislikes:
   get:
@@ -217,7 +217,7 @@ ViewPointDislikeMe:
         content:
           application/json:
             schema:
-              $ref: "../schemas/viewpoint.yaml#/ViewPoint"
+              $ref: "../schemas/viewpoint.yaml#/ViewPointReaction"
 
 ViewPointFacts:
   get:

--- a/schemas/fact.yaml
+++ b/schemas/fact.yaml
@@ -21,3 +21,13 @@ Fact:
       type: array
       items:
         $ref: "../schemas/reference.yaml#/Reference"
+
+UpdateFact:
+  type: object
+  properties:
+    title:
+      type: string
+    references:
+      type: array
+      items:
+        $ref: "../schemas/reference.yaml#/UpdateReference"

--- a/schemas/fact.yaml
+++ b/schemas/fact.yaml
@@ -4,19 +4,22 @@ Fact:
     id:
       type: string
       format: uuid
-    create_at:
+    createdAt:
       type: string
       format: date-time
-    updated_at:
+    updatedAt:
       type: string
       format: date-time
     title:
       type: string
-    author_id:
+    authorId:
       type: string
       format: uuid
-    author_name:
+    authorName:
       type: string
+    authorAvatar:
+      type: string
+      format: uri
     references:
       type: array
       items:

--- a/schemas/fact.yaml
+++ b/schemas/fact.yaml
@@ -17,3 +17,7 @@ Fact:
       format: uuid
     author_name:
       type: string
+    references:
+      type: array
+      items:
+        $ref: "../schemas/reference.yaml#/Reference"

--- a/schemas/reference.yaml
+++ b/schemas/reference.yaml
@@ -15,3 +15,10 @@ Reference:
       format: byte
     title:
       type: string
+
+UpdateReference:
+  type: object
+  properties:
+    url:
+      type: string
+      format: uri

--- a/schemas/reference.yaml
+++ b/schemas/reference.yaml
@@ -4,7 +4,7 @@ Reference:
     id:
       type: string
       format: uuid
-    create_at:
+    createdAt:
       type: string
       format: date-time
     url:

--- a/schemas/viewpoint.yaml
+++ b/schemas/viewpoint.yaml
@@ -26,6 +26,24 @@ ViewPoint:
     authorName:
       type: string
       description: The name of the author of the ViewPoint
+    userLiked:
+      type: boolean
+      description: Whether the user liked the ViewPoint
+    userReasonable:
+      type: boolean
+      description: Whether the user found the ViewPoint reasonable
+    userDisliked:
+      type: boolean
+      description: Whether the user disliked the ViewPoint
+    likeCount:
+      type: integer
+      description: The number of likes the ViewPoint has
+    ReasonableCount:
+      type: integer
+      description: The number of resonables the ViewPoint has
+    dislikeCount:
+      type: integer
+      description: The number of dislikes the ViewPoint has
     facts:
       type: array
       items:

--- a/schemas/viewpoint.yaml
+++ b/schemas/viewpoint.yaml
@@ -26,15 +26,8 @@ ViewPoint:
     authorName:
       type: string
       description: The name of the author of the ViewPoint
-    userLiked:
-      type: boolean
-      description: Whether the user liked the ViewPoint
-    userReasonable:
-      type: boolean
-      description: Whether the user found the ViewPoint reasonable
-    userDisliked:
-      type: boolean
-      description: Whether the user disliked the ViewPoint
+    userReaction:
+      $ref: "#/ViewPointReaction"
     likeCount:
       type: integer
       description: The number of likes the ViewPoint has
@@ -52,21 +45,11 @@ ViewPoint:
 ViewPointReaction:
   type: object
   properties:
-    userLiked:
-      type: boolean
-      description: Whether the user liked the ViewPoint
-    userReasonable:
-      type: boolean
-      description: Whether the user found the ViewPoint reasonable
-    userDisliked:
-      type: boolean
-      description: Whether the user disliked the ViewPoint
-    likeCount:
-      type: integer
-      description: The number of likes the ViewPoint has
-    ReasonableCount:
-      type: integer
-      description: The number of resonables the ViewPoint has
-    dislikeCount:
-      type: integer
-      description: The number of dislikes the ViewPoint has
+    reaction:
+      type: string
+      description: The reaction of the user
+      format: enum
+      enum:
+        - LIKE
+        - REASONABLE
+        - DISLIKE

--- a/schemas/viewpoint.yaml
+++ b/schemas/viewpoint.yaml
@@ -26,12 +26,15 @@ ViewPoint:
     authorName:
       type: string
       description: The name of the author of the ViewPoint
+    authorAvatar:
+      type: string
+      format: uri
     userReaction:
       $ref: "#/ViewPointReaction"
     likeCount:
       type: integer
       description: The number of likes the ViewPoint has
-    ReasonableCount:
+    reasonableCount:
       type: integer
       description: The number of resonables the ViewPoint has
     dislikeCount:

--- a/schemas/viewpoint.yaml
+++ b/schemas/viewpoint.yaml
@@ -26,6 +26,19 @@ ViewPoint:
     authorName:
       type: string
       description: The name of the author of the ViewPoint
+
+ViewPointReaction:
+  type: object
+  properties:
+    userLiked:
+      type: boolean
+      description: Whether the user liked the ViewPoint
+    userReasonable:
+      type: boolean
+      description: Whether the user found the ViewPoint reasonable
+    userDisliked:
+      type: boolean
+      description: Whether the user disliked the ViewPoint
     likeCount:
       type: integer
       description: The number of likes the ViewPoint has

--- a/schemas/viewpoint.yaml
+++ b/schemas/viewpoint.yaml
@@ -53,6 +53,7 @@ ViewPointReaction:
       description: The reaction of the user
       format: enum
       enum:
+        - NONE
         - LIKE
         - REASONABLE
         - DISLIKE

--- a/schemas/viewpoint.yaml
+++ b/schemas/viewpoint.yaml
@@ -53,3 +53,19 @@ ViewPointReaction:
         - LIKE
         - REASONABLE
         - DISLIKE
+
+UpdateViewPoint:
+  type: object
+  properties:
+    title:
+      type: string
+      description: The name of the ViewPoint
+    content:
+      type: string
+      description: The content of the ViewPoint
+    facts:
+      type: array
+      items:
+        type: string
+        format: uuid
+        description: The unique identifier of the fact

--- a/schemas/viewpoint.yaml
+++ b/schemas/viewpoint.yaml
@@ -26,6 +26,10 @@ ViewPoint:
     authorName:
       type: string
       description: The name of the author of the ViewPoint
+    facts:
+      type: array
+      items:
+        $ref: "../schemas/fact.yaml#/Fact"
 
 ViewPointReaction:
   type: object


### PR DESCRIPTION
## Type of changes
Refacotr

## Purpose
### Add ViewPointReaction schema
Incorporate the ViewPointReaction response schema into the following endpoints:
- /api/viewpoint/{id}/like/me
- /api/viewpoint/{id}/reasonable/me
- /api/viewpoint/{id}/dislike/me

By replying with a ViewPointReaction schema, that enable the frontend to easily identify and display the current reaction status (like, reasonable, dislike) after these endpoint responsed.

### Embed Facts into the schema of the Viewpoint
The new optimization strategy aims to minimize API requests by delivering all required data in a single response rather than multiple queries. The first page loads only the content visible on the device screen, with the second page preloading immediately after the first is fully loaded.

To achieve the above purpose, the Fact Schema is embedded within the Viewpoint Schema.

## Additional information
### ViewPointReaction
```mermaid
classDiagram
  class ViewPointReaction {
    int likeCount 
    int ReasonableCount 
    int dislikeCount
    boolean userLiked 
    boolean userReasonable
    boolean userDisliked 
  }
```

### ViewPoint
Add

```mermaid
classDiagram
  class ViewPoint {
    boolean userLiked 
    boolean userReasonable
    boolean userDisliked 
    list[fact] facts
  }