### PR TITLE
Update swagger port to 8000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN curl -L https://github.com/swagger-api/swagger-ui/archive/v4.15.5.tar.gz | t
 RUN echo "window.onload = function() { window.ui = SwaggerUIBundle({ url: './swagger.yaml', dom_id: '#swagger-ui' }); };" > /app/public/swagger-initializer.js
 RUN sed -i 's|<title>Swagger UI</title>|<title>API Documentation</title>|' /app/public/index.html
 
-EXPOSE 8080
-CMD watchmedo auto-restart --patterns="*.yaml;*.html;*.js;*.css" --recursive -- python3 -m http.server 8080 --directory /app/public
+EXPOSE 8000
+CMD watchmedo auto-restart --patterns="*.yaml;*.html;*.js;*.css" --recursive -- python3 -m http.server 8000 --directory /app/public

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ IMAGE_NAME = swagger-server
 CONTAINER_NAME = swagger-server-container
 MOCK_IMAGE_NAME = stoplight/prism:4
 MOCK_CONTAINER_NAME = mock-api-container
-HOST_PORT = 8080
-CONTAINER_PORT = 8080
+HOST_PORT = 8000
+CONTAINER_PORT = 8000
 MOCK_ENDPOINT_PORT = 4010
 CUR_DIR = $(shell pwd)
 


### PR DESCRIPTION
Since the current recommended port to access the backend via local port forwarding is 8080, I recommend updating the Swagger port to something different than 8080 to prevent port conflicts.