### PR TITLE
Add reply endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,6 +26,8 @@ paths:
     $ref: "./paths/viewpoint.yaml#/ViewPointFacts"
   /api/viewpoint/{id}/fact/{factId}:
     $ref: "./paths/viewpoint.yaml#/ViewPointFact"
+  /api/viewpoint/{id}/replies:
+    $ref: "./paths/reply.yaml#/ViewpointReplies"
   # Fact
   /api/facts:
     $ref: "./paths/fact.yaml#/Facts"
@@ -35,7 +37,13 @@ paths:
     $ref: "./paths/fact.yaml#/FactReferences"
   /api/fact/{id}/reference/{referenceId}:
     $ref: "./paths/fact.yaml#/FactReference"
-
+  # Reply
+  /api/reply:
+    $ref: "./paths/reply.yaml#/Reply"
+  /api/reply/{id}/reaction/me:
+    $ref: "./paths/reply.yaml#/ReplyReaction"
+  /api/reply/{id}/facts:
+    $ref: "./paths/reply.yaml#/ReplyFacts"
 components:
   schemas:
     Issue:
@@ -58,5 +66,14 @@ components:
       $ref: "./schemas/reference.yaml#/Reference"
     UpdateReference:
       $ref: "./schemas/reference.yaml#/UpdateReference"
+    Reply:
+      $ref: "./schemas/reply.yaml#/Reply"
+    UpdateReply:
+      $ref: "./schemas/reply.yaml#/UpdateReply"
+    ReplyReaction:
+      $ref: "./schemas/reply.yaml#/ReplyReaction"
+    QuoteReply:
+      $ref: "./schemas/reply.yaml#/QuoteReply"
     Pagination:
       $ref: "./schemas/page.yaml#/Page"
+      

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,12 +38,11 @@ paths:
   /api/fact/{id}/reference/{referenceId}:
     $ref: "./paths/fact.yaml#/FactReference"
   # Reply
-  /api/reply:
+  /api/reply/{id}:
     $ref: "./paths/reply.yaml#/Reply"
   /api/reply/{id}/reaction/me:
     $ref: "./paths/reply.yaml#/ReplyReaction"
-  /api/reply/{id}/facts:
-    $ref: "./paths/reply.yaml#/ReplyFacts"
+
 components:
   schemas:
     Issue:

--- a/parameters/sort.yaml
+++ b/parameters/sort.yaml
@@ -1,6 +1,6 @@
 Sort:
   name: sort
   in: query
-  default: createAt,asc
+  default: createdAt,asc
   schema:
     type: string

--- a/paths/reply.yaml
+++ b/paths/reply.yaml
@@ -1,0 +1,185 @@
+ViewpointReplies:
+  get: 
+    summary: List replies
+    description: This endpoint will return all replies of a viewpoints
+    operationId: getRepliesByViewpoint
+    tags:
+      - ViewPoint
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+      - $ref: "../parameters/sort.yaml#/Sort"
+      - $ref: "../parameters/page.yaml#/Page"
+      - $ref: "../parameters/size.yaml#/Size" 
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: array
+                  items:
+                    $ref: "../schemas/fact.yaml#/Fact"
+                page:
+                  $ref: "../schemas/page.yaml#/Page"
+  post:
+    summary: Create a new reply
+    description: This endpoint is used to create a new reply for an viewpoint
+    operationId: createReply
+    tags:
+      - ViewPoint
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/reply.yaml#/UpdateReply"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/reply.yaml#/Reply"
+
+Reply:
+  get:
+    summary: Get specific reply information
+    description: This endpoint returns specific reply information by reply id
+    operationId: getReply
+    tags:
+      - Reply
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/reply.yaml#/Reply"
+  put:
+    summary: Update a reply
+    description: This endpoint is used to update a reply
+    operationId: updateReply
+    tags:
+      - Reply
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/reply.yaml#/UpdateReply"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/reply.yaml#/Reply"
+  delete:
+    summary: Delete a reply
+    description: This endpoint is used to delete a reply
+    operationId: deleteReply
+    tags:
+      - Reply
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    responses:
+      '204':
+        description: No content
+
+ReplyReaction:
+  post:
+    summary: React to a reply
+    description: This endpoint is used to react to a reply
+    operationId: reactToReply
+    tags:
+      - Reply
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/reply.yaml#/ReplyReaction"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/reply.yaml#/ReplyReaction"
+
+ReplyFacts:
+  get:
+    summary: List facts of a reply
+    description: This endpoint returns all facts of a reply
+    operationId: getFactsOfReply
+    tags:
+      - Reply
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+      - $ref: "../parameters/page.yaml#/Page"
+      - $ref: "../parameters/size.yaml#/Size"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: array
+                  items:
+                    $ref: "../schemas/fact.yaml#/Fact"
+                page:
+                  $ref: "../schemas/page.yaml#/Page"
+  post:
+    summary: Add a fact to a reply
+    description: This endpoint is used to add a fact to a reply
+    operationId: addFactToReply
+    tags:
+      - Reply
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              factId:
+                type: string
+                format: uuid
+    responses:
+      '204':
+        description: No content
+
+ReplyFact:
+  delete:
+    summary: Unlink a fact from a reply
+    description: This endpoint is used to remove a fact from a reply
+    operationId: removeFactFromReply
+    tags:
+      - Reply
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+      - name: factId
+        in: path
+        required: true
+        description: The uuid of fact
+        schema:
+          type: string
+          format: uuid
+    responses:
+      '204':
+        description: No content
+        

--- a/paths/reply.yaml
+++ b/paths/reply.yaml
@@ -21,7 +21,7 @@ ViewpointReplies:
                 content:
                   type: array
                   items:
-                    $ref: "../schemas/fact.yaml#/Fact"
+                    $ref: "../schemas/reply.yaml#/Reply"
                 page:
                   $ref: "../schemas/page.yaml#/Page"
   post:
@@ -66,6 +66,7 @@ Reply:
     operationId: updateReply
     tags:
       - Reply
+      - Admin
     parameters:
       - $ref: "../parameters/requestId.yaml#/RequestUid"
     requestBody:
@@ -87,6 +88,7 @@ Reply:
     operationId: deleteReply
     tags:
       - Reply
+      - Admin
     parameters:
       - $ref: "../parameters/requestId.yaml#/RequestUid"
     responses:
@@ -107,7 +109,7 @@ ReplyReaction:
       content:
         application/json:
           schema:
-            $ref: "../schemas/reply.yaml#/ReplyReaction"
+            $ref: "../schemas/reply.yaml#/UpdateReplyReaction"
     responses:
       '200':
         description: Successful response
@@ -115,71 +117,4 @@ ReplyReaction:
           application/json:
             schema:
               $ref: "../schemas/reply.yaml#/ReplyReaction"
-
-ReplyFacts:
-  get:
-    summary: List facts of a reply
-    description: This endpoint returns all facts of a reply
-    operationId: getFactsOfReply
-    tags:
-      - Reply
-    parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestUid"
-      - $ref: "../parameters/page.yaml#/Page"
-      - $ref: "../parameters/size.yaml#/Size"
-    responses:
-      '200':
-        description: Successful response
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                content:
-                  type: array
-                  items:
-                    $ref: "../schemas/fact.yaml#/Fact"
-                page:
-                  $ref: "../schemas/page.yaml#/Page"
-  post:
-    summary: Add a fact to a reply
-    description: This endpoint is used to add a fact to a reply
-    operationId: addFactToReply
-    tags:
-      - Reply
-    parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestUid"
-    requestBody:
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              factId:
-                type: string
-                format: uuid
-    responses:
-      '204':
-        description: No content
-
-ReplyFact:
-  delete:
-    summary: Unlink a fact from a reply
-    description: This endpoint is used to remove a fact from a reply
-    operationId: removeFactFromReply
-    tags:
-      - Reply
-    parameters:
-      - $ref: "../parameters/requestId.yaml#/RequestUid"
-      - name: factId
-        in: path
-        required: true
-        description: The uuid of fact
-        schema:
-          type: string
-          format: uuid
-    responses:
-      '204':
-        description: No content
         

--- a/schemas/reply.yaml
+++ b/schemas/reply.yaml
@@ -28,7 +28,17 @@ Reply:
       type: string
       format: uri
     userReaction:
-      $ref: "#/ReplyReaction"
+      type: object
+      properties:
+        reaction:
+          type: string
+          description: The reaction of the user
+          format: enum
+          enum:
+            - NONE
+            - LIKE
+            - REASONABLE
+            - DISLIKE
     likeCount:
       type: integer
       description: The number of likes the Reply has

--- a/schemas/reply.yaml
+++ b/schemas/reply.yaml
@@ -1,0 +1,90 @@
+Reply:
+  type: object
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: The unique identifier of the Reply
+    createdAt:
+      type: string
+      format: date-time
+      description: The date and time the Reply was created
+    updatedAt:
+      type: string
+      format: date-time
+      description: The date and time the Reply was last updated
+    content:
+      type: string
+      description: The content of the Reply
+      example: "[[Quote]](0) This is a reply [first imported fact](0) [second imported fact](1,2) [[Quote]](1)"
+    authorId:
+      type: string
+      format: uuid
+      description: The unique identifier of the author of the Reply
+    authorName:
+      type: string
+      description: The name of the author of the Reply
+    authorAvatar:
+      type: string
+      format: uri
+    userReaction:
+      $ref: "#/ReplyReaction"
+    likeCount:
+      type: integer
+      description: The number of likes the Reply has
+    reasonableCount:
+      type: integer
+      description: The number of reasonables the Reply has
+    dislikeCount:
+      type: integer
+      description: The number of dislikes the Reply
+    quotes:
+      type: array
+      description: The list of quotes
+      items:
+        $ref: "#/QuoteReply"
+    facts:
+      type: array
+      items:
+          $ref: "../schemas/fact.yaml#/Fact"
+
+ReplyReaction:
+  type: object
+  properties:
+    reaction:
+      type: string
+      description: The reaction of the user
+      format: enum
+      enum:
+        - NONE
+        - LIKE
+        - REASONABLE
+        - DISLIKE
+
+UpdateReply:
+  type: object
+  properties:
+    content:
+      type: string
+      description: The content of the Reply
+    facts:
+      type: array
+      items:
+        type: string
+        format: uuid
+        description: The unique identifier of the fact
+
+QuoteReply:
+  type: object
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: The id of the Reply
+    authorName:
+      type: string
+      description: The name of the author of the Reply
+    content:
+      type: string
+      description: The part of the content of the Reply
+      

--- a/schemas/reply.yaml
+++ b/schemas/reply.yaml
@@ -60,6 +60,32 @@ ReplyReaction:
         - LIKE
         - REASONABLE
         - DISLIKE
+    likeCount:
+      type: integer
+      description: The number of likes the Reply has
+    reasonableCount:
+      type: integer
+      description: The number of reasonables the Reply has
+    dislikeCount:
+      type: integer
+      description: The number of dislikes the Reply
+    updatedAt:
+      type: string
+      format: date-time
+      description: The date and time the Reply was last updated
+
+UpdateReplyReaction:
+  type: object
+  properties:
+    reaction:
+      type: string
+      description: The reaction of the user
+      format: enum
+      enum:
+        - NONE
+        - LIKE
+        - REASONABLE
+        - DISLIKE
 
 UpdateReply:
   type: object
@@ -67,6 +93,10 @@ UpdateReply:
     content:
       type: string
       description: The content of the Reply
+    quotes:
+      type: array
+      items:
+        $ref: "#/UpdateQuoteReply"
     facts:
       type: array
       items:
@@ -77,14 +107,41 @@ UpdateReply:
 QuoteReply:
   type: object
   properties:
-    id:
+    replyId:
       type: string
       format: uuid
       description: The id of the Reply
+    authorId:
+      type: string
+      format: uuid
+      description: The unique identifier of the author of the Reply
     authorName:
       type: string
       description: The name of the author of the Reply
+    authorAvatar:
+      type: string
+      format: uri
     content:
       type: string
       description: The part of the content of the Reply
-      
+    start:
+      type: integer
+      description: The start position of the content of the Reply
+    end:
+      type: integer
+      description: The end position of the content of the Reply
+
+UpdateQuoteReply:
+  type: object
+  properties:
+    replyId:
+      type: string
+      format: uuid
+      description: The id of the Reply
+    start:
+      type: integer
+      description: The start position of the content of the Reply
+    end:
+      type: integer
+      description: The end position of the content of the Reply
+


### PR DESCRIPTION
## Type of Change
Feature

## Purpose
- Add Reply related endpoint
  - `/api/viewpoint/{id}/replies`
  - `/api/reply`
  - `/api/reply/{id}/reaction/me`
  - `/api/reply/{id}/facts`
 
## Additional Information
### About the format of the content of Reply:
- `[[Quote]](0)` refers to the related quote in the `quotes` of the response. the integer in the parentheses refers to the index of the quote
- `[first imported fact](0)` refers to the related fact in the `facts` of the response.  the text in the brackets refers to the text which should be shown. the integer in the parentheses refers to the index of the facts. it could be a sequence of integer separate by commas such as `(0,1)` and `(2,3,4)`