### PR TITLE
Add notification endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -35,6 +35,13 @@ paths:
     $ref: "./paths/fact.yaml#/FactReferences"
   /api/fact/{id}/reference/{referenceId}:
     $ref: "./paths/fact.yaml#/FactReference"
+  # Notification
+  /api/notifications:
+    $ref: "./paths/notification.yaml#/Notifications"
+  /api/notification/user/{userId}:
+    $ref: "./paths/notification.yaml#/NotificationUser"
+  /api/notification/{id}:
+    $ref: "./paths/notification.yaml#/Notification"
 
 components:
   schemas:
@@ -60,3 +67,5 @@ components:
       $ref: "./schemas/reference.yaml#/UpdateReference"
     Pagination:
       $ref: "./schemas/page.yaml#/Page"
+    Notification:
+      $ref: "./schemas/notification.yaml#/Notification"

--- a/paths/notification.yaml
+++ b/paths/notification.yaml
@@ -50,3 +50,23 @@ Notification:
           application/json:
             schema:
               $ref: "../schemas/notification.yaml#/Notification"
+  put:
+    summary: Update a notification
+    description: This endpoint is used to update a notification
+    operationId: updateNotification
+    tags:
+      - Notification
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/notification.yaml#/UpdateNotification"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/notification.yaml#/UpdateNotification"

--- a/paths/notification.yaml
+++ b/paths/notification.yaml
@@ -1,0 +1,52 @@
+Notifications:
+  get:
+    summary: List notifications
+    description: This endpoint returns all notifications for all users
+    operationId: getNotifications
+    tags:
+      - Notification
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "../schemas/notification.yaml#/Notification"
+
+NotificationUser:
+  get:
+    summary: List notifications for a specific user
+    description: This endpoint returns all notifications for a specific user
+    operationId: getNotificationsUser
+    tags:
+      - Notification
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "../schemas/notification.yaml#/Notification"
+
+Notification:
+  get:
+    summary: Get a notification by id
+    description: This endpoint returns a notification
+    operationId: getNotification
+    tags:
+      - Notification
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/notification.yaml#/Notification"

--- a/schemas/notification.yaml
+++ b/schemas/notification.yaml
@@ -12,14 +12,11 @@ Notification:
       format: uri
     icon:
       type: string
-      format: uri
-      #  or byte?
+      format: uri #  or byte?
     title:
       type: string
     content:
       type: string
-    read:
-      type: boolean
     userId:
       type: string
       format: uuid
@@ -29,20 +26,15 @@ Notification:
     status:
       # 0: unread, 1: read, 2: deleted ...  maybe change to enum
       type: string
-    readAt:
+    UpdateAt:
       type: string
       format: date-time
-    readByMe:
-      type: boolean
 
 UpdateNotification:
   type: object
   properties:
-    read:
-      type: boolean
+    id:
+      type: string
+      format: uuid
     status:
       type: string
-      # 0: unread, 1: read, 2: deleted ...
-    readAt:
-      type: string
-      format: date-time

--- a/schemas/notification.yaml
+++ b/schemas/notification.yaml
@@ -24,13 +24,25 @@ Notification:
       type: string
       format: uuid
     type:
-      # 0: like, 1: comment, 2: follow, 3: system ...
+      # 0: like, 1: comment, 2: follow, 3: system ... maybe change to enum
       type: string
     status:
-      # 0: unread, 1: read, 2: deleted ...
+      # 0: unread, 1: read, 2: deleted ...  maybe change to enum
       type: string
     readAt:
       type: string
       format: date-time
     readByMe:
       type: boolean
+
+UpdateNotification:
+  type: object
+  properties:
+    read:
+      type: boolean
+    status:
+      type: string
+      # 0: unread, 1: read, 2: deleted ...
+    readAt:
+      type: string
+      format: date-time

--- a/schemas/notification.yaml
+++ b/schemas/notification.yaml
@@ -1,0 +1,36 @@
+Notification:
+  type: object
+  properties:
+    id:
+      type: string
+      format: uuid
+    createdAt:
+      type: string
+      format: date-time
+    url:
+      type: string
+      format: uri
+    icon:
+      type: string
+      format: uri
+      #  or byte?
+    title:
+      type: string
+    content:
+      type: string
+    read:
+      type: boolean
+    userId:
+      type: string
+      format: uuid
+    type:
+      # 0: like, 1: comment, 2: follow, 3: system ...
+      type: string
+    status:
+      # 0: unread, 1: read, 2: deleted ...
+      type: string
+    readAt:
+      type: string
+      format: date-time
+    readByMe:
+      type: boolean


### PR DESCRIPTION
## Type of Changes
Feature

## Purpose
- Add Notification related endpoint
  - `/api/notifications`
  - `/api/notification/user/{userId}`
  - `/api/notification/{id}`

## Additional Information
- `/api/notifications` (GET) is used for retrieving a list of all notifications.
- `/api/notification/user/{userId}` (GET) is used for fetching notifications for a specific user.
- `/api/notification/{id}` (GET) is used for searching a notification by its unique ID.
- `/api/notification/{id}` (PUT) is used for updating the notification status, such as marking it as read or unread.

## Considerations
- Unsure about the design of the notification `status`. Should it be implemented as an enum, or should a boolean flag like `hasRead` be used instead? Need further clarification on the best approach for representing the notification state.
  - What statuses should be supported (e.g., "sent", "read", "delivered")?
- Not certain what the `type` of notifications should be. Should `type` be represented as an enum? What types of notifications should we support (e.g., "message", "friend_request", "like", "comment")?
- Considering whether to include an `icon` for each notification. If an icon is required, should it be stored as a URI (link to an image) or as a byte array (binary data)? Further analysis needed on which approach to take.