### PR TITLE
Add the api spec for getting website title and icon

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -49,8 +49,8 @@ paths:
   /api/reply/{id}/reaction/me:
     $ref: "./paths/reply.yaml#/ReplyReaction"
   # Website Title
-  /api/websitetitle:
-    $ref: "./paths/websitetitle.yaml#/WebsiteTitle"
+  /api/website/check:
+    $ref: "./paths/website.yaml#/WebsiteCheck"
 
 components:
   schemas:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -48,6 +48,9 @@ paths:
     $ref: "./paths/reply.yaml#/Reply"
   /api/reply/{id}/reaction/me:
     $ref: "./paths/reply.yaml#/ReplyReaction"
+  # Website Title
+  /api/websitetitle:
+    $ref: "./paths/websitetitle.yaml#/WebsiteTitle"
 
 components:
   schemas:
@@ -81,4 +84,3 @@ components:
       $ref: "./schemas/reply.yaml#/QuoteReply"
     Pagination:
       $ref: "./schemas/page.yaml#/Page"
-      

--- a/paths/website.yaml
+++ b/paths/website.yaml
@@ -1,4 +1,4 @@
-WebsiteTitle:
+WebsiteCheck:
   get:
     summary: Get Website Title and Icon
     description: Get the title and icon of the website.

--- a/paths/websitetitle.yaml
+++ b/paths/websitetitle.yaml
@@ -1,0 +1,39 @@
+WebsiteTitle:
+  get:
+    summary: Get Website Title and Icon
+    description: Get the title and icon of the website.
+    requsestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              url:
+                type: string
+                format: uri
+    responses:
+      "200": # when the website of the given URL is found
+        description: OK
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: # return 'NO TITLE' when the title is not found
+                  type: string
+                icon: # return '' (empty string) when the icon is not found
+                  type: string
+                  format: uri
+
+      "400": # when the website of the given URL is not found
+        description: Website not found
+        content:
+          application/json:
+            schema:
+              $ref: "../definitions/errorOccurred.yaml#/ErrorOccurred"
+            example:
+              type: "WEBSITE_NOT_FOUND"
+              statue: 400
+              title: "Requested website not found"
+              detail: "The website of the given URL is not found. Check the URL and try again."


### PR DESCRIPTION
Due to the CORS problem, the front end can't directly check whether the URL the user inputted when creating the fact is valid. Also, the inability to load the title and icon during the preview is quite a serious UX drawback. Therefore, we need a backend API to handle this task.