### PR TITLE
Add subscription endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -48,6 +48,11 @@ paths:
     $ref: "./paths/reply.yaml#/Reply"
   /api/reply/{id}/reaction/me:
     $ref: "./paths/reply.yaml#/ReplyReaction"
+  # Subscription
+  /api/subscription/subscribe:
+    $ref: "./paths/subscription.yaml#/Subscribe"
+  /api/subscription/unsubscribe:
+    $ref: "./paths/subscription.yaml#/Unsubscribe"
 
 components:
   schemas:
@@ -79,6 +84,10 @@ components:
       $ref: "./schemas/reply.yaml#/ReplyReaction"
     QuoteReply:
       $ref: "./schemas/reply.yaml#/QuoteReply"
+    Subscribe:
+      $ref: "./schemas/subscription.yaml#/Subcribe"
+    Unsubscribe:
+      $ref: "./schemas/subscription.yaml#/Unsubcribe"
     Pagination:
       $ref: "./schemas/page.yaml#/Page"
       

--- a/paths/subscription.yaml
+++ b/paths/subscription.yaml
@@ -1,0 +1,33 @@
+Subscribe:
+  post:
+    summary: subscribe to push service
+    description: This endpoint is used to add subscription to backend
+    operationId: subscribePushService
+    tags:
+      - Subscription
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/subscription.yaml#/Subscribe"
+    responses:
+      '204':
+        $ref: "../definitions/processSuccess.yaml"
+
+Unsubscribe:
+  post:
+    summary: unsubscribe to push service
+    description: This endpoint is used to remove subscription from backend
+    operationId: unsubscribePushService
+    tags:
+      - Subscription
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/subscription.yaml#/Unsubscribe"
+    responses:
+      '204':
+        $ref: "../definitions/processSuccess.yaml"

--- a/schemas/subscription.yaml
+++ b/schemas/subscription.yaml
@@ -1,0 +1,22 @@
+Subscribe:
+  type: object
+  properties:
+    endpoint:
+      type: string
+      description: The endpoint of push service
+    keys:
+      type: object
+      properties:
+        p256hd:
+          type: string
+          description: p256hd of the subscription of the pushManager of the browser
+        auth:
+          type: string
+          description: auth of the subscription of the pushManager of the browser
+
+Unsubscribe:
+  type: object
+  properties:
+    endpoint:
+      type: string
+      description: The endpoint of push service

--- a/schemas/subscription.yaml
+++ b/schemas/subscription.yaml
@@ -7,9 +7,9 @@ Subscribe:
     keys:
       type: object
       properties:
-        p256hd:
+        p256dh:
           type: string
-          description: p256hd of the subscription of the pushManager of the browser
+          description: p256dh of the subscription of the pushManager of the browser
         auth:
           type: string
           description: auth of the subscription of the pushManager of the browser


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add `/api/subscription/subscribe` for storing subscriptions of Push Service
- Add `/api/subscription/unsubscribe` for removing specific subscription of Push Service

## Additional Information
- The details of `endpoint`, `p256dh` and `auth` in schemas and how Web Push works are in the [doc](https://www.notion.so/sdc-nycu/Web-Push-Manual-1837dadd804080188d49fda14699d4d3)