### PR TITLE
Add create reference without fact endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,6 +38,9 @@ paths:
     $ref: "./paths/fact.yaml#/FactReferences"
   /api/fact/{id}/reference/{referenceId}:
     $ref: "./paths/fact.yaml#/FactReference"
+  # Reference
+  /api/references:
+    $ref: "./paths/reference.yaml#/References"
   # Timeline
   /api/issue/{id}/timeline:
     $ref: "./paths/timeline.yaml#/Timelines"

--- a/paths/reference.yaml
+++ b/paths/reference.yaml
@@ -1,0 +1,20 @@
+References:
+  post:
+    summary: Create a new reference without a fact
+    description: This endpoint is used to create a new reference and without a fact
+    operationId: createReference
+    tags:
+      - Reference
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/reference.yaml#/UpdateReference"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/reference.yaml#/Reference"


### PR DESCRIPTION
## Type of Changes
Feature

## Purpose
Currently, only `/fact/{id}/references` exists. Since v0.2 requires creating references before facts, this PR adds the `/references` endpoint.

## Additional Information
### Add create reference without fact endpoint

POST `/api/references`

Request
```json
{
  "url": "github.com",
}
```

Response
```json
{
  "id": "c8c0ddfe-4428-4fc6-90bc-3b2ed373914b",
  "url": "https://github.com",
  "icon": "https://github.githubassets.com/favicons/favicon.svg",
  "title": "GitHub · Build and ship software on a single, collaborative platform · GitHub",
  "create_at": "2025-01-24T01:28:16.686296787"
}
```