### PR TITLE
Add internal profile endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -72,8 +72,10 @@ paths:
   /api/users:
     $ref: "./paths/user.yaml#/Users"
   # Internal
+  /api/internal/users/profile:
+    $ref: "/paths/internal.yaml#/InternalProfiles"
   /api/internal/users/profile/{userId}:
-    $ref: "/paths/internal.yaml#/Profile"
+    $ref: "/paths/internal.yaml#/InternalProfile"
 
 components:
   schemas:
@@ -111,5 +113,5 @@ components:
       $ref: "./schemas/subscription.yaml#/Unsubscribe"
     Pagination:
       $ref: "./schemas/page.yaml#/Page"
-    Profile:
-      $ref: "./schemas/internal.yaml#/Profile"
+    InternalProfile:
+      $ref: "./schemas/internal.yaml#/InternalProfile"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -71,6 +71,9 @@ paths:
     $ref: "./paths/user.yaml#/User"
   /api/users:
     $ref: "./paths/user.yaml#/Users"
+  # Internal
+  /api/internal/users/profile/{userId}:
+    $ref: "/paths/internal.yaml#/Profile"
 
 components:
   schemas:
@@ -108,3 +111,5 @@ components:
       $ref: "./schemas/subscription.yaml#/Unsubcribe"
     Pagination:
       $ref: "./schemas/page.yaml#/Page"
+    Profile:
+      $ref: "./schemas/internal.yaml#/Profile"

--- a/paths/internal.yaml
+++ b/paths/internal.yaml
@@ -1,8 +1,28 @@
-Profile:
+InternalProfiles:
   get:
-    summary: Get user's profile information
+    summary: List internal user profiles
+    description: This endpoint returns all internal user profiles
+    operationId: getInternalProfiles
+    tags:
+      - Internal
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: array
+                  items:
+                    $ref: "../schemas/internal.yaml#/InternalProfile"
+
+InternalProfile:
+  get:
+    summary: Get internal user's profile information
     description: This endpoint returns specific user's profile information by user id
-    operationId: getProfile
+    operationId: getInternalProfile
     tags:
       - Internal
     parameters:
@@ -13,4 +33,4 @@ Profile:
         content:
           application/json:
             schema:
-              $ref: "../schemas/internal.yaml#/Profile"
+              $ref: "../schemas/internal.yaml#/InternalProfile"

--- a/paths/internal.yaml
+++ b/paths/internal.yaml
@@ -1,0 +1,16 @@
+Profile:
+  get:
+    summary: Get user's fact information
+    description: This endpoint returns specific user's profile information by user id
+    operationId: getProfile
+    tags:
+      - Internal
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/internal.yaml#/Profile"

--- a/paths/internal.yaml
+++ b/paths/internal.yaml
@@ -1,6 +1,6 @@
 Profile:
   get:
-    summary: Get user's fact information
+    summary: Get user's profile information
     description: This endpoint returns specific user's profile information by user id
     operationId: getProfile
     tags:

--- a/schemas/internal.yaml
+++ b/schemas/internal.yaml
@@ -1,4 +1,4 @@
-Profile:
+InternalProfile:
   type: object
   properties:
     user_id:

--- a/schemas/internal.yaml
+++ b/schemas/internal.yaml
@@ -1,0 +1,31 @@
+Profile:
+  type: object
+  properties:
+    user_id:
+      type: string
+      format: uuid
+    gender:
+      type: string
+    occupation:
+      type: string
+      nullable: true
+    location:
+      type: string
+    browsing_tags:
+      type: array
+      items:
+        type: string
+    search_keywords:
+      type: array
+      items:
+        type: string
+    created_at:
+      type: string
+      format: date-time
+    last_active_at:
+      type: string
+      format: date-time
+    activity_frequency:
+      type: object
+    user_top_ip:
+      type: object


### PR DESCRIPTION
## Type of changes
Feature

## Purpose
- Add `/api/internal/users/profile` to get all internal user profile information
- Add `/api/internal/users/profile/{userId}` to get specific internal user profile information by user ID

## Additional Information
- The schemas for `activity_frequency` and `user_top_ip` have yet to be designed.