### PR TITLE
Add service account endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -73,6 +73,13 @@ paths:
     $ref: "./paths/user.yaml#/User"
   /api/users:
     $ref: "./paths/user.yaml#/Users"
+  #  ServiceAccount
+  /api/internal/service-account/me:
+    $ref: "./paths/service-account.yaml#/ServiceAccountMe"
+  /api/internal/service-account/{serviceId}:
+    $ref: "./paths/service-account.yaml#/ServiceAccount"
+  /api/internal/service-accounts:
+    $ref: "./paths/service-account.yaml#/ServiceAccounts"
 
 components:
   schemas:

--- a/paths/service-account.yaml
+++ b/paths/service-account.yaml
@@ -1,0 +1,100 @@
+ServiceAccountMe:
+  get:
+    summary: Get Service Account Information
+    description: Get the information of the service account.
+    tags:
+      - ServiceAccount
+    responses:
+      "200":
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/service-account.yaml#/ServiceAccount"
+
+ServiceAccount:
+  get:
+    summary: Get Service Account Information
+    description: Get the information of the service account.
+    tags:
+      - ServiceAccount
+      - Admin
+    parameters:
+      - name: serviceId
+        in: path
+        required: true
+        description: The id of the service account
+        schema:
+          type: string
+    responses:
+      "200":
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/service-account.yaml#/ServiceAccount"
+  delete:
+    summary: Delete Service Account
+    description: Delete the service account.
+    tags:
+      - ServiceAccount
+      - Admin
+    parameters:
+      - name: serviceId
+        in: path
+        required: true
+        description: The id of the service account
+        schema:
+          type: string
+          format: uuid
+    responses:
+      "204":
+        description: No Content
+
+ServiceAccounts:
+  get:
+    summary: Get Service Accounts
+    description: Get the list of service accounts.
+    tags:
+      - ServiceAccount
+      - Admin
+    responses:
+      "200":
+        description: OK
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "../schemas/service-account.yaml#/ServiceAccount"
+  post:
+    summary: Create Service Account
+    description: Create a new service account.
+    tags:
+      - ServiceAccount
+      - Admin
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              role:
+                type: string
+                enum:
+                  - ROLE_SERVICE_ACCOUNT_READ
+    responses:
+      "200":
+        description: OK
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "../schemas/service-account.yaml#/ServiceAccount"
+                - properties:
+                    token:
+                      type: string
+                      format: uuid

--- a/paths/service-account.yaml
+++ b/paths/service-account.yaml
@@ -13,26 +13,6 @@ ServiceAccountMe:
               $ref: "../schemas/service-account.yaml#/ServiceAccount"
 
 ServiceAccount:
-  get:
-    summary: Get Service Account Information
-    description: Get the information of the service account.
-    tags:
-      - ServiceAccount
-      - Admin
-    parameters:
-      - name: serviceId
-        in: path
-        required: true
-        description: The id of the service account
-        schema:
-          type: string
-    responses:
-      "200":
-        description: OK
-        content:
-          application/json:
-            schema:
-              $ref: "../schemas/service-account.yaml#/ServiceAccount"
   delete:
     summary: Delete Service Account
     description: Delete the service account.

--- a/schemas/service-account.yaml
+++ b/schemas/service-account.yaml
@@ -1,0 +1,12 @@
+ServiceAccount:
+  type: object
+  properties:
+    id:
+      type: string
+      format: uuid
+    name:
+      type: string
+    role:
+      type: string
+      enum:
+        - ROLE_SERVICE_ACCOUNT_READ


### PR DESCRIPTION
## Type of changes
Feature

## Purpose
- Add `/api/internal/service-account/me` to get the current login service account information
- Add `/api/internal/service-account/{id}` to delete service account by id
- Add `/api/internal/service-accounts` to get all service accounts or create a service account, then respond with the token

## Additional Information
Implementation: https://github.com/commonground-project/backend/pull/65