### PR TITLE
Add text suggestion endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -93,6 +93,11 @@ paths:
     $ref: "./paths/service-account.yaml#/ServiceAccount"
   /api/internal/service-accounts:
     $ref: "./paths/service-account.yaml#/ServiceAccounts"
+  # Text-suggestion
+  /api/text-suggestion:
+    $ref: "./paths/text-suggestion.yaml#/TextSuggestion"
+  /api/edited-text-suggestion:
+    $ref: "./paths/text-suggestion.yaml#/EditedTextSuggestion"
 
 components:
   schemas:
@@ -140,3 +145,13 @@ components:
       $ref: "./schemas/internal.yaml#/InternalProfile"
     InternalViewpoint:
       $ref: "./schemas/internal.yaml#/InternalViewpoint"
+    TextSuggestion:
+      $ref: "./schemas/text-suggestion.yaml#/TextSuggestion"
+    TextSuggestionResponse:
+      $ref: "./schemas/text-suggestion.yaml#/TextSuggestionResponse"
+    EditedTextSuggestion:
+      $ref: "./schemas/text-suggestion.yaml#/EditedTextSuggestion"
+    EditedTextSuggestionRequest:
+      $ref: "./schemas/text-suggestion.yaml#/EditedTextSuggestionRequest"
+    EditedTextSuggestionResponse:
+      $ref: "./schemas/text-suggestion.yaml#/EditedTextSuggestionResponse"

--- a/paths/text-suggestion.yaml
+++ b/paths/text-suggestion.yaml
@@ -1,0 +1,57 @@
+TextSuggestion:
+  post:
+    summary: Analyze the user's text input and provide suggestions
+    description: When the user enters text for the first time, the system will check the content and highlight phrases that may need adjustments.
+    operationId: getTextSuggestions
+    tags:
+      - TextSuggestion
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              text:
+                type: string
+                description: The original input text from the user that has not yet been analyzed.
+    responses:
+      "200":
+        description: Returns the original text with highlighted areas and suggestions.
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/text-suggestion.yaml#/TextSuggestionResponse"
+
+EditedTextSuggestion:
+  post:
+    summary: Analyze edited text and provide further recommendations
+    description: When the user modifies the suggested text, this API ensures that the adjustments remain in line with rational discussion principles.
+    operationId: getEditedTextSuggestions
+    tags:
+      - TextSuggestion
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              text:
+                type: string
+                description: The original text input.
+              edited_text:
+                type: string
+                description: The user’s modified text.
+              suggestions:
+                type: array
+                description: The list of previous AI suggestions and the user’s modifications.
+                items:
+                  $ref: "../schemas/text-suggestion.yaml#/EditedTextSuggestionRequest"
+    responses:
+      "200":
+        description: Returns the analyzed edited text with additional recommendations.
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/text-suggestion.yaml#/EditedTextSuggestionResponse"

--- a/schemas/text-suggestion.yaml
+++ b/schemas/text-suggestion.yaml
@@ -1,0 +1,65 @@
+TextSuggestion:
+  type: object
+  properties:
+    message:
+      type: string
+      description: The suggested text with highlighted parts (<sugX>).
+    feedback:
+      type: string
+      description: The feedback message explaining why the suggestion was made.
+    replacement:
+      type: string
+      description: The recommended replacement for the highlighted text.
+
+TextSuggestionResponse:
+  type: object
+  properties:
+    text:
+      type: string
+      description: The original input text from the user.
+    suggestions:
+      type: array
+      description: A list of suggested modifications, each containing highlighted problematic areas.
+      items:
+        $ref: "#/TextSuggestion"
+
+EditedTextSuggestion:
+  type: object
+  properties:
+    edited_message:
+      type: string
+      description: The modified message after user edits, with highlighted parts (<sugX>).
+    feedback:
+      type: string
+      description: The feedback message explaining why further modifications are needed.
+    replacement:
+      type: string
+      description: The recommended replacement for the edited text.
+
+EditedTextSuggestionRequest:
+  type: object
+  properties:
+    message:
+      type: string
+      description: The original suggested message from the AI.
+    edited_message:
+      type: string
+      description: The user's modified version of the message.
+    feedback:
+      type: string
+      description: The original AI feedback explaining the suggested change.
+    replacement:
+      type: string
+      description: The original AI recommended replacement.
+
+EditedTextSuggestionResponse:
+  type: object
+  properties:
+    edited_text:
+      type: string
+      description: The user-modified text.
+    suggestions:
+      type: array
+      description: A list of suggested modifications for the edited text.
+      items:
+        $ref: "#/EditedTextSuggestion"


### PR DESCRIPTION
## Type of changes
Feature

## Purpose
Introduce a new feature to create user guidance by integrating AI-driven text suggestions.
- Add `/api/text-suggestion` to analyze user input and provide suggestions for improving neutrality and rational discussion
- Add `/api/edited-text-suggestion` to process user-modified text, ensuring alignment with discussion principles while offering further recommendations if necessary.