### PR TITLE
Add gender, age, and occupation fields to user schema

### DIFF
--- a/schemas/user.yaml
+++ b/schemas/user.yaml
@@ -22,8 +22,9 @@ User:
         - FEMALE
         - NON_BINARY
         - PREFER_NOT_TO_SAY
-    age:
-      type: number
+    birthday:
+      type: string
+      format: date-time
     occupation:
       type: string
       format: enum
@@ -63,8 +64,9 @@ UserSetup:
         - FEMALE
         - NON_BINARY
         - PREFER_NOT_TO_SAY
-    age:
-      type: number
+    birthday:
+      type: string
+      format: date-time
     occupation:
       type: string
       format: enum

--- a/schemas/user.yaml
+++ b/schemas/user.yaml
@@ -14,6 +14,39 @@ User:
         - ROLE_NOT_SETUP
         - ROLE_USER
         - ROLE_ADMIN
+    gender:
+      type: string
+      format: enum
+      enum:
+        - MALE
+        - FEMALE
+        - NON_BINARY
+        - PREFER_NOT_TO_SAY
+    age:
+      type: number
+    occupation:
+      type: string
+      format: enum
+      enum:
+        - STUDENTS
+        - FREELANCERS_SELF_EMPLOYED
+        - EDUCATION_ACADEMIA
+        - HEALTHCARE_HEALTH
+        - TECHNOLOGY_ENGINEERING
+        - ARTS_DESIGN
+        - FINANCE_LAW
+        - PUBLIC_SERVICE
+        - BUSINESS_SALES
+        - MEDIA_COMMUNICATION
+        - TRAVEL_HOSPITALITY
+        - ENVIRONMENTAL_SCIENCE_POLICY
+        - ENERGY_INFRASTRUCTURE
+        - CONSTRUCTION_BUILDING
+        - LOGISTICS_SUPPLY_CHAIN_MANAGEMENT
+        - TRANSPORTATION_SERVICES
+        - AGRICULTURAL_WORKERS
+        - ENVIRONMENTAL_CONSERVATION_RESOURCE_MANAGEMENT
+        - RETIRED_NOT_WORKING
 
 UserSetup:
   type: object
@@ -22,6 +55,39 @@ UserSetup:
       type: string
     nickname:
       type: string
+    gender:
+      type: string
+      format: enum
+      enum:
+        - MALE
+        - FEMALE
+        - NON_BINARY
+        - PREFER_NOT_TO_SAY
+    age:
+      type: number
+    occupation:
+      type: string
+      format: enum
+      enum:
+        - STUDENTS
+        - FREELANCERS_SELF_EMPLOYED
+        - EDUCATION_ACADEMIA
+        - HEALTHCARE_HEALTH
+        - TECHNOLOGY_ENGINEERING
+        - ARTS_DESIGN
+        - FINANCE_LAW
+        - PUBLIC_SERVICE
+        - BUSINESS_SALES
+        - MEDIA_COMMUNICATION
+        - TRAVEL_HOSPITALITY
+        - ENVIRONMENTAL_SCIENCE_POLICY
+        - ENERGY_INFRASTRUCTURE
+        - CONSTRUCTION_BUILDING
+        - LOGISTICS_SUPPLY_CHAIN_MANAGEMENT
+        - TRANSPORTATION_SERVICES
+        - AGRICULTURAL_WORKERS
+        - ENVIRONMENTAL_CONSERVATION_RESOURCE_MANAGEMENT
+        - RETIRED_NOT_WORKING
 
 UserSettings:
   type: object


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add `gender`, `age` and `occupation` fields to user schema

## Additional Information
- List of gender
   - MALE
   - FEMALE
   - NON_BINARY
   - PREFER_NOT_TO_SAY
- List of occupation
   - STUDENTS
   - FREELANCERS_SELF_EMPLOYED
   - EDUCATION_ACADEMIA
   - HEALTHCARE_HEALTH
   - TECHNOLOGY_ENGINEERING
   - ARTS_DESIGN
   - FINANCE_LAW
   - PUBLIC_SERVICE
   - BUSINESS_SALES
   - MEDIA_COMMUNICATION
   - TRAVEL_HOSPITALITY
   - ENVIRONMENTAL_SCIENCE_POLICY
   - ENERGY_INFRASTRUCTURE
   - CONSTRUCTION_BUILDING
   - LOGISTICS_SUPPLY_CHAIN_MANAGEMENT
   - TRANSPORTATION_SERVICES
   - AGRICULTURAL_WORKERS
   - ENVIRONMENTAL_CONSERVATION_RESOURCE_MANAGEMENT
   - RETIRED_NOT_WORKING