### PR TITLE
Add onboarding viewpoint preference api

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -32,6 +32,8 @@ paths:
     $ref: "./paths/viewpoint.yaml#/ViewPointFact"
   /api/viewpoint/{id}/replies:
     $ref: "./paths/reply.yaml#/ViewpointReplies"
+  /api/viewpoint/{id}/preference/me:
+    $ref: "./paths/viewpoint.yaml#/ViewpointPreference"
 
   # Fact
   /api/facts:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -32,7 +32,7 @@ paths:
     $ref: "./paths/viewpoint.yaml#/ViewPointFact"
   /api/viewpoint/{id}/replies:
     $ref: "./paths/reply.yaml#/ViewpointReplies"
-  /api/viewpoint/{id}/preference/me:
+  /api/viewpoints/preference/me:
     $ref: "./paths/viewpoint.yaml#/ViewpointPreference"
 
   # Fact

--- a/paths/viewpoint.yaml
+++ b/paths/viewpoint.yaml
@@ -223,11 +223,15 @@ ViewpointPreference:
       content:
         application/json:
           schema:
-            $ref: "../schemas/viewpoint.yaml#/ViewpointPreference"
+            type: array
+            items:
+              $ref: "../schemas/viewpoint.yaml#/ViewpointPreference"
     responses:
       '200':
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: "../schemas/viewpoint.yaml#/ViewpointPreference"
+              type: array
+              items:
+                $ref: "../schemas/viewpoint.yaml#/ViewpointPreference"

--- a/paths/viewpoint.yaml
+++ b/paths/viewpoint.yaml
@@ -208,3 +208,26 @@ ViewPointFact:
     responses:
       '204':
         description: No content
+
+ViewpointPreference:
+  post:
+    summary: Set viewpoint preference
+    description: This endpoint is used to set viewpoint preference
+    operationId: addViewpointPreference
+    tags:
+      - ViewPoint
+    parameters:
+      - $ref: "../parameters/requestId.yaml#/RequestUid"
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/viewpoint.yaml#/ViewpointPreference"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/viewpoint.yaml#/ViewpointPreference"

--- a/paths/viewpoint.yaml
+++ b/paths/viewpoint.yaml
@@ -226,6 +226,14 @@ ViewpointPreference:
             type: array
             items:
               $ref: "../schemas/viewpoint.yaml#/ViewpointPreference"
+          examples:
+            example1:
+              summary: Example of viewpoint preference
+              value:
+                - id: "704a1650-3f50-4bdc-b530-5fd59b8e80a6"
+                  preference: "INTEREST"
+                - id: "c7852a9e-187b-4f39-b11c-9437b29ecfc5"
+                  preference: "DISINTEREST"
     responses:
       '200':
         description: Successful response
@@ -235,3 +243,11 @@ ViewpointPreference:
               type: array
               items:
                 $ref: "../schemas/viewpoint.yaml#/ViewpointPreference"
+            examples:
+              example1:
+                summary: Example of viewpoint preference
+                value:
+                  - id: "704a1650-3f50-4bdc-b530-5fd59b8e80a6"
+                    preference: "INTEREST"
+                  - id: "c7852a9e-187b-4f39-b11c-9437b29ecfc5"
+                    preference: "DISINTEREST"

--- a/schemas/viewpoint.yaml
+++ b/schemas/viewpoint.yaml
@@ -76,3 +76,14 @@ UpdateViewPoint:
         type: string
         format: uuid
         description: The unique identifier of the fact
+
+ViewpointPreference:
+  type: object
+  properties:
+    preference:
+      type: string
+      description: The preference of the user
+      format: enum
+      enum:
+        - INTEREST
+        - DISINTEREST

--- a/schemas/viewpoint.yaml
+++ b/schemas/viewpoint.yaml
@@ -80,6 +80,10 @@ UpdateViewPoint:
 ViewpointPreference:
   type: object
   properties:
+    id:
+      type: string
+      format: uuid
+      description: The unique identifier of the ViewPoint
     preference:
       type: string
       description: The preference of the user


### PR DESCRIPTION
## Type of change
- Feature

## Purpose
- Add `/api/viewpoint/preference/me` to express interest or disinterest in a viewpoint during user onboarding.

## Additional Information
- The `preference` field is an enum; only `INTEREST` and `DISINTEREST` are allowed values.