### PR TITLE
Add fact search api

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -103,6 +103,10 @@ paths:
   /api/internal/facts:
     $ref: "./paths/internal.yaml#/InternalFacts"
 
+  # Search
+  /api/searchFact:
+    $ref: "./paths/search.yaml#/Search"
+
   #  ServiceAccount
   /api/internal/service-account/me:
     $ref: "./paths/service-account.yaml#/ServiceAccountMe"
@@ -185,6 +189,10 @@ components:
     JWT:
       $ref: "./schemas/jwt.yaml#/JWT"
       
+    # Search
+    Search:
+      $ref: "./schemas/search.yaml#/Search"
+    
     # ServiceAccount
     ServiceAccount:
       $ref: "./schemas/service-account.yaml#/ServiceAccount"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -188,11 +188,7 @@ components:
     # JWT
     JWT:
       $ref: "./schemas/jwt.yaml#/JWT"
-      
-    # Search
-    Search:
-      $ref: "./schemas/search.yaml#/Search"
-    
+
     # ServiceAccount
     ServiceAccount:
       $ref: "./schemas/service-account.yaml#/ServiceAccount"

--- a/paths/search.yaml
+++ b/paths/search.yaml
@@ -1,0 +1,25 @@
+Search:
+  get:
+    summary: Search for relevant facts
+    description: Returns a list of fact IDs relevant to the search query, based on both fact and reference entity matching.
+    operationId: searchFacts
+    tags:
+      - Search
+    parameters:
+      - $ref: "../parameters/page.yaml#/Page"
+      - $ref: "../parameters/size.yaml#/Size"
+      - $ref: "../parameters/search.yaml#/Search"
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: array
+                  items:
+                    $ref: "../schemas/search.yaml#/Search"
+                page:
+                  $ref: "../schemas/page.yaml#/Page"

--- a/paths/search.yaml
+++ b/paths/search.yaml
@@ -6,9 +6,14 @@ Search:
     tags:
       - Search
     parameters:
+      - name: query
+        in: query
+        required: true
+        description: The search query string used to match facts and references.
+        schema:
+          type: string
       - $ref: "../parameters/page.yaml#/Page"
       - $ref: "../parameters/size.yaml#/Size"
-      - $ref: "../parameters/search.yaml#/Search"
     responses:
       '200':
         description: Successful response

--- a/paths/search.yaml
+++ b/paths/search.yaml
@@ -24,7 +24,8 @@ Search:
               properties:
                 content:
                   type: array
-                  items: # fact id
+                  items:
+                    description: List of matched fact IDs
                     type: string
                     format: uuid
                 page:

--- a/paths/search.yaml
+++ b/paths/search.yaml
@@ -24,7 +24,8 @@ Search:
               properties:
                 content:
                   type: array
-                  items:
-                    $ref: "../schemas/search.yaml#/Search"
+                  items: # fact id
+                    type: string
+                    format: uuid
                 page:
                   $ref: "../schemas/page.yaml#/Page"

--- a/paths/search.yaml
+++ b/paths/search.yaml
@@ -25,8 +25,7 @@ Search:
                 content:
                   type: array
                   items:
-                    description: List of matched fact IDs
-                    type: string
-                    format: uuid
+                    description: List of matched facts
+                    $ref: "../schemas/fact.yaml#/Fact"
                 page:
                   $ref: "../schemas/page.yaml#/Page"

--- a/schemas/search.yaml
+++ b/schemas/search.yaml
@@ -1,0 +1,8 @@
+Search:
+  type: object
+  properties:
+    factIds:
+      type: array
+      items:
+        type: string
+        format: uuid

--- a/schemas/search.yaml
+++ b/schemas/search.yaml
@@ -1,8 +1,0 @@
-Search:
-  type: object
-  properties:
-    factIds:
-      type: array
-      items:
-        type: string
-        format: uuid


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
Add GET `/searchFact?query=` endpoint to support full-text search on:
- fact titles
- reference titles
- reference descriptions

The API performs a MeiliSearch query and returns a list of matched fact IDs based on both fact and reference entity relevance.